### PR TITLE
Propagate exceptions from asynchronous workers

### DIFF
--- a/src/discolinks/cli.py
+++ b/src/discolinks/cli.py
@@ -175,7 +175,10 @@ async def find_links(
     for worker in workers:
         worker.cancel()
 
-    await asyncio.gather(*workers, return_exceptions=True)
+    try:
+        await asyncio.gather(*workers)
+    except asyncio.CancelledError:
+        pass
 
 
 async def main_async(


### PR DESCRIPTION
Only the `CancelledError` needs to be caught since it's normal in this case. Now, assertion errors and other uncaught exceptions originating from workers will make the program exit with an error, as expected.