### PR TITLE
Fix checking of link status code in async worker

### DIFF
--- a/integration_tests/test_link_404_with_another_link.py
+++ b/integration_tests/test_link_404_with_another_link.py
@@ -1,0 +1,42 @@
+import json
+import subprocess
+
+from flask import Blueprint
+
+from . import util
+
+
+def make_blueprint() -> Blueprint:
+    blueprint = Blueprint("main", __name__)
+
+    @blueprint.route("/")
+    def root():
+        return """<a href="/foo">\n"""
+
+    @blueprint.route("/foo")
+    def foo():
+        return ("""<a href="/bar">\n""", 404)
+
+    return blueprint
+
+
+def test_json(http_server) -> None:
+    http_server(blueprint=make_blueprint(), port=5000)
+
+    result = subprocess.run(
+        util.command(url="http://localhost:5000", json=True),
+        capture_output=True,
+    )
+
+    assert result.returncode == 1
+    assert json.loads(result.stdout.decode()) == {
+        "http://localhost:5000/foo": {
+            "status_code": 404,
+            "origins": [
+                {
+                    "page": "http://localhost:5000",
+                    "href": "/foo",
+                },
+            ],
+        },
+    }

--- a/src/discolinks/cli.py
+++ b/src/discolinks/cli.py
@@ -114,7 +114,7 @@ async def investigate_link(
     link_response = await request_link_get(requester=requester, link=link)
     link_store.add_result(link=link, result=link_response.result)
 
-    if not link_response.result.ok:
+    if not link_response.result.ok():
         return frozenset()
 
     page_links = get_links(response=link_response.response, link=link)


### PR DESCRIPTION
Because I mistakenly used the method object, it would always be evaluated to `True`.