### PR TITLE
Add parsing tests for hrefs with a trailing slash

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -33,6 +33,26 @@ def test_get_hrefs(body: str, expected: list[tuple[Link, LinkOrigin]]):
             Link.from_url("http://example.net/foo"),
         ),
         (
+            "bar",
+            Link.from_url("http://example.net/foo"),
+            Link.from_url("http://example.net/bar"),
+        ),
+        (
+            "bar",
+            Link.from_url("http://example.net/foo/"),
+            Link.from_url("http://example.net/foo/bar"),
+        ),
+        (
+            "/bar",
+            Link.from_url("http://example.net/foo"),
+            Link.from_url("http://example.net/bar"),
+        ),
+        (
+            "/bar",
+            Link.from_url("http://example.net/foo/"),
+            Link.from_url("http://example.net/bar"),
+        ),
+        (
             "http://example.org",
             Link.from_url("http://example.net"),
             Link.from_url("http://example.org"),


### PR DESCRIPTION
This ensures that we won't break the current behavior, which is correct as far as I'm aware (checked in Firefox):

- when finding `href="bar"` at http://example.net/foo, go to http://example.net/bar.
- when finding `href="bar"` at http://example.net/foo/, go to http://example.net/foo/bar.
- when finding `href="/bar"` on any page, go to http://example.net/bar.