### PR TITLE
Transpose the returned page/link structure

### DIFF
--- a/integration_tests/test_fragments.py
+++ b/integration_tests/test_fragments.py
@@ -44,17 +44,25 @@ def test_json(http_server, url) -> None:
 
     assert result.returncode == 0
     assert json.loads(result.stdout.decode()) == {
-        "http://localhost:5000/foo": {
-            "status_code": 200,
-            "origins": [
+        "http://localhost:5000": {
+            "links": [
                 {
-                    "page": "http://localhost:5000",
                     "href": "/foo#bar",
+                    "destination": {
+                        "url": "http://localhost:5000/foo",
+                        "status_code": 200,
+                    },
                 },
                 {
-                    "page": "http://localhost:5000",
                     "href": "/foo#baz",
+                    "destination": {
+                        "url": "http://localhost:5000/foo",
+                        "status_code": 200,
+                    },
                 },
             ],
+        },
+        "http://localhost:5000/foo": {
+            "links": [],
         },
     }

--- a/integration_tests/test_link_404.py
+++ b/integration_tests/test_link_404.py
@@ -27,10 +27,8 @@ def test_text(http_server) -> None:
     assert result.returncode == 1
     assert result.stdout.decode() == util.output_str(
         """
-        http://localhost:5000/foo
-          status code: 404
-          origins:
-            http://localhost:5000: /foo
+        http://localhost:5000
+          - /foo: 404
         """
     )
 
@@ -45,12 +43,14 @@ def test_json(http_server) -> None:
 
     assert result.returncode == 1
     assert json.loads(result.stdout.decode()) == {
-        "http://localhost:5000/foo": {
-            "status_code": 404,
-            "origins": [
+        "http://localhost:5000": {
+            "links": [
                 {
-                    "page": "http://localhost:5000",
                     "href": "/foo",
+                    "destination": {
+                        "url": "http://localhost:5000/foo",
+                        "status_code": 404,
+                    },
                 },
             ],
         },

--- a/integration_tests/test_link_404_with_another_link.py
+++ b/integration_tests/test_link_404_with_another_link.py
@@ -30,12 +30,14 @@ def test_json(http_server) -> None:
 
     assert result.returncode == 1
     assert json.loads(result.stdout.decode()) == {
-        "http://localhost:5000/foo": {
-            "status_code": 404,
-            "origins": [
+        "http://localhost:5000": {
+            "links": [
                 {
-                    "page": "http://localhost:5000",
                     "href": "/foo",
+                    "destination": {
+                        "url": "http://localhost:5000/foo",
+                        "status_code": 404,
+                    },
                 },
             ],
         },

--- a/integration_tests/test_link_error.py
+++ b/integration_tests/test_link_error.py
@@ -26,12 +26,14 @@ def test_json(http_server) -> None:
 
     assert result.returncode == 1
     assert json.loads(result.stdout.decode()) == {
-        "http://localhost:5001": {
-            "status_code": None,
-            "origins": [
+        "http://localhost:5000": {
+            "links": [
                 {
-                    "page": "http://localhost:5000",
                     "href": "http://localhost:5001",
+                    "destination": {
+                        "url": "http://localhost:5001",
+                        "status_code": None,
+                    },
                 },
             ],
         },

--- a/integration_tests/test_no_scheme.py
+++ b/integration_tests/test_no_scheme.py
@@ -27,11 +27,13 @@ def test_json(http_server) -> None:
     assert result.returncode == 0
     assert json.loads(result.stdout.decode()) == {
         "http://localhost:5000": {
-            "status_code": 200,
-            "origins": [
+            "links": [
                 {
-                    "page": "http://localhost:5000",
                     "href": "",
+                    "destination": {
+                        "url": "http://localhost:5000",
+                        "status_code": 200,
+                    },
                 },
             ],
         },

--- a/integration_tests/test_other_server.py
+++ b/integration_tests/test_other_server.py
@@ -27,12 +27,14 @@ def test_json(http_server) -> None:
 
     assert result.returncode == 0
     assert json.loads(result.stdout.decode()) == {
-        "http://localhost:5001": {
-            "status_code": 200,
-            "origins": [
+        "http://localhost:5000": {
+            "links": [
                 {
-                    "page": "http://localhost:5000",
                     "href": "http://localhost:5001",
+                    "destination": {
+                        "url": "http://localhost:5001",
+                        "status_code": 200,
+                    },
                 },
             ],
         },

--- a/integration_tests/test_recursive.py
+++ b/integration_tests/test_recursive.py
@@ -55,25 +55,36 @@ def test_json(max_parallel_requests: int, http_server) -> None:
 
     assert result.returncode == 0
     assert json.loads(result.stdout.decode()) == {
-        "http://localhost:5000/": {
-            "status_code": 200,
-            "origins": [
+        "http://localhost:5000": {
+            "links": [
                 {
-                    "href": "/",
-                    "page": "http://localhost:5000/foo",
+                    "href": "/foo",
+                    "destination": {
+                        "url": "http://localhost:5000/foo",
+                        "status_code": 200,
+                    },
+                },
+            ],
+        },
+        "http://localhost:5000/": {
+            "links": [
+                {
+                    "href": "/foo",
+                    "destination": {
+                        "url": "http://localhost:5000/foo",
+                        "status_code": 200,
+                    },
                 },
             ],
         },
         "http://localhost:5000/foo": {
-            "status_code": 200,
-            "origins": [
+            "links": [
                 {
-                    "page": "http://localhost:5000",
-                    "href": "/foo",
-                },
-                {
-                    "page": "http://localhost:5000/",
-                    "href": "/foo",
+                    "href": "/",
+                    "destination": {
+                        "url": "http://localhost:5000/",
+                        "status_code": 200,
+                    },
                 },
             ],
         },

--- a/integration_tests/test_redirect.py
+++ b/integration_tests/test_redirect.py
@@ -33,16 +33,25 @@ def test_json(http_server) -> None:
 
     assert result.returncode == 0
     assert json.loads(result.stdout.decode()) == {
-        "http://localhost:5000/": {
-            "status_code": 200,
-            "origins": [
+        "http://localhost:5000": {
+            "links": [
                 {
                     "href": "/",
-                    "page": "http://localhost:5000",
+                    "destination": {
+                        "url": "http://localhost:5000/",
+                        "status_code": 200,
+                    },
                 },
+            ],
+        },
+        "http://localhost:5000/": {
+            "links": [
                 {
                     "href": "/",
-                    "page": "http://localhost:5000/",
+                    "destination": {
+                        "url": "http://localhost:5000/",
+                        "status_code": 200,
+                    },
                 },
             ],
         },

--- a/integration_tests/test_url_head_405.py
+++ b/integration_tests/test_url_head_405.py
@@ -44,12 +44,14 @@ def test_json(http_server) -> None:
 
     assert result.returncode == 0
     assert json.loads(result.stdout.decode()) == {
-        "http://localhost:5001": {
-            "status_code": 200,
-            "origins": [
+        "http://localhost:5000": {
+            "links": [
                 {
-                    "page": "http://localhost:5000",
                     "href": "http://localhost:5001",
+                    "destination": {
+                        "url": "http://localhost:5001",
+                        "status_code": 200,
+                    },
                 },
             ],
         },

--- a/src/discolinks/analyzer.py
+++ b/src/discolinks/analyzer.py
@@ -1,0 +1,48 @@
+from typing import Mapping, Optional, Sequence
+
+import attrs
+
+from .core import Url
+from .link_store import UrlInfo
+
+
+@attrs.frozen
+class Destination:
+    url: Url
+    status_code: Optional[int]
+
+    def ok(self):
+        return self.status_code is not None and not (400 <= self.status_code < 600)
+
+
+@attrs.frozen
+class LinkResult:
+    href: str
+    destination: Destination
+
+    def ok(self):
+        return self.destination.ok()
+
+
+@attrs.frozen
+class Page:
+    links: Sequence[LinkResult]
+
+
+def analyze(url_infos: Mapping[Url, UrlInfo]) -> Mapping[Url, Page]:
+    return {
+        url: Page(
+            links=tuple(
+                LinkResult(
+                    href=link.href,
+                    destination=Destination(
+                        url=link.url,
+                        status_code=url_infos[link.url].status_code,
+                    ),
+                )
+                for link in info.links
+            )
+        )
+        for (url, info) in url_infos.items()
+        if info.links is not None
+    }

--- a/src/discolinks/core.py
+++ b/src/discolinks/core.py
@@ -1,4 +1,3 @@
-from typing import Optional
 from urllib.parse import urldefrag, urlparse
 
 import attrs
@@ -33,27 +32,6 @@ class Url:
 
 
 @attrs.frozen
-class LinkOrigin:
-    """
-    Information about the origin of a link.
-
-    - `link.url` is the address where the link was found.
-     -`link.href` is the HTML "href" attribute of the link.
-    """
-
-    url: Url
+class Link:
     href: str
-
-
-@attrs.frozen
-class LinkInfo:
-    status_code: Optional[int]
-    origins: frozenset[LinkOrigin]
-
-    def ok(self):
-        return self.status_code is not None and not (400 <= self.status_code < 600)
-
-    def add_origin(self, origin: LinkOrigin) -> "LinkInfo":
-        return LinkInfo(
-            status_code=self.status_code, origins=self.origins | frozenset([origin])
-        )
+    url: Url

--- a/src/discolinks/export.py
+++ b/src/discolinks/export.py
@@ -1,33 +1,34 @@
 import json
 from typing import Any, Mapping
 
-from .core import LinkInfo, LinkOrigin, Url
+from .analyzer import Destination, LinkResult, Page
+from .core import Url
 
 
-def origin_to_json(origin: LinkOrigin) -> Any:
+def destination_to_json(destination: Destination) -> Any:
     return {
-        "page": origin.url.full,
-        "href": origin.href,
+        "url": destination.url.full,
+        "status_code": destination.status_code,
     }
 
 
-def info_to_json(info: LinkInfo) -> Any:
+def link_to_json(link: LinkResult) -> Any:
     return {
-        "status_code": info.status_code,
-        "origins": [
-            origin_to_json(origin)
-            for origin in sorted(
-                info.origins,
-                key=lambda origin: (origin.url.full, origin.href),
-            )
-        ],
+        "href": link.href,
+        "destination": destination_to_json(link.destination),
     }
 
 
-def links_to_json(links: Mapping[Url, LinkInfo]) -> Any:
-    return {url.full: info_to_json(info) for (url, info) in links.items()}
+def page_to_json(page: Page) -> Any:
+    return {
+        "links": [link_to_json(link) for link in page.links],
+    }
 
 
-def dump_json(links: Mapping[Url, LinkInfo]) -> str:
-    obj = links_to_json(links=links)
+def pages_to_json(pages: Mapping[Url, Page]) -> Any:
+    return {url.full: page_to_json(page) for (url, page) in pages.items()}
+
+
+def dump_json(pages: Mapping[Url, Page]) -> str:
+    obj = pages_to_json(pages=pages)
     return json.dumps(obj)

--- a/src/discolinks/html.py
+++ b/src/discolinks/html.py
@@ -3,7 +3,7 @@ from urllib.parse import urldefrag, urljoin, urlparse
 
 import bs4
 
-from .core import LinkOrigin, Url
+from .core import Link, Url
 
 
 def get_hrefs(body: str) -> Sequence[str]:
@@ -34,8 +34,7 @@ def parse_href(href: str, base_url: Url) -> Url:
     return Url.from_str(url)
 
 
-def get_links(body: str, url: Url) -> Sequence[tuple[Url, LinkOrigin]]:
+def get_links(body: str, url: Url) -> Sequence[Link]:
     return [
-        (parse_href(href, base_url=url), LinkOrigin(href=href, url=url))
-        for href in get_hrefs(body)
+        Link(href=href, url=parse_href(href, base_url=url)) for href in get_hrefs(body)
     ]

--- a/src/discolinks/link_store.py
+++ b/src/discolinks/link_store.py
@@ -1,20 +1,14 @@
-from typing import Optional
+from typing import Mapping, Optional, Sequence
 
 import attrs
 
-from .core import LinkInfo, LinkOrigin, Url
-
-
-@attrs.frozen
-class PageLink:
-    href: str
-    url: Url
+from .core import Link, Url
 
 
 @attrs.frozen
 class UrlInfo:
     status_code: Optional[int]
-    links: Optional[frozenset[PageLink]]
+    links: Optional[Sequence[Link]]
 
     def link_urls(self) -> frozenset[Url]:
         if self.links is None:
@@ -43,30 +37,5 @@ class LinkStore:
         self.seen_urls.update(new_urls)
         return new_urls
 
-    def get_link_infos(self) -> dict[Url, LinkInfo]:
-        """
-        Return link infos for accumulated URL results.
-
-        This should be called only at the end of the crawling.
-        """
-
-        infos: dict[Url, LinkInfo] = dict()
-
-        for (origin_url, url_info) in self.pages.items():
-            if url_info.links is None:
-                continue
-
-            for page_link in url_info.links:
-                url = page_link.url
-                link_info = infos.get(url)
-                origin = LinkOrigin(url=origin_url, href=page_link.href)
-                if link_info is None:
-                    status_code = self.pages[page_link.url].status_code
-                    infos[url] = LinkInfo(
-                        status_code=status_code,
-                        origins=frozenset([origin]),
-                    )
-                else:
-                    infos[url] = link_info.add_origin(origin)
-
-        return infos
+    def get_url_infos(self) -> Mapping[Url, UrlInfo]:
+        return self.pages

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,6 +1,8 @@
+from typing import Sequence
+
 import pytest
 
-from discolinks.core import LinkOrigin, Url
+from discolinks.core import Url
 from discolinks.html import get_hrefs, parse_href
 
 
@@ -13,7 +15,7 @@ from discolinks.html import get_hrefs, parse_href
         ("""<a href="mailto:foo@example.net">""", []),
     ],
 )
-def test_get_hrefs(body: str, expected: list[tuple[Url, LinkOrigin]]):
+def test_get_hrefs(body: str, expected: Sequence[str]):
     result = get_hrefs(body=body)
 
     assert list(result) == expected


### PR DESCRIPTION
Instead of returning a map of {link → pages where the link was found},
we return a map of {page → links found on the page}.

This is a continuation of an earlier commit
(2a84da1906f8e0fdee065b5417dc3708729a850d) which only changed the
internal representation. The present commit changes the external
representation, that is, what is returned to the user as text or JSON.

Hopefully, this representation is more intuitive and will enable more
use cases like the representation of redirects.