### PR TITLE
Store and show HTTP redirects

### DIFF
--- a/integration_tests/test_fragments.py
+++ b/integration_tests/test_fragments.py
@@ -48,17 +48,23 @@ def test_json(http_server, url) -> None:
             "links": [
                 {
                     "href": "/foo#bar",
-                    "destination": {
-                        "url": "http://localhost:5000/foo",
-                        "status_code": 200,
-                    },
+                    "url": "http://localhost:5000/foo",
+                    "results": [
+                        {
+                            "type": "response",
+                            "status_code": 200,
+                        }
+                    ],
                 },
                 {
                     "href": "/foo#baz",
-                    "destination": {
-                        "url": "http://localhost:5000/foo",
-                        "status_code": 200,
-                    },
+                    "url": "http://localhost:5000/foo",
+                    "results": [
+                        {
+                            "type": "response",
+                            "status_code": 200,
+                        }
+                    ],
                 },
             ],
         },

--- a/integration_tests/test_link_404.py
+++ b/integration_tests/test_link_404.py
@@ -47,10 +47,13 @@ def test_json(http_server) -> None:
             "links": [
                 {
                     "href": "/foo",
-                    "destination": {
-                        "url": "http://localhost:5000/foo",
-                        "status_code": 404,
-                    },
+                    "url": "http://localhost:5000/foo",
+                    "results": [
+                        {
+                            "type": "response",
+                            "status_code": 404,
+                        }
+                    ],
                 },
             ],
         },

--- a/integration_tests/test_link_404_with_another_link.py
+++ b/integration_tests/test_link_404_with_another_link.py
@@ -34,10 +34,13 @@ def test_json(http_server) -> None:
             "links": [
                 {
                     "href": "/foo",
-                    "destination": {
-                        "url": "http://localhost:5000/foo",
-                        "status_code": 404,
-                    },
+                    "url": "http://localhost:5000/foo",
+                    "results": [
+                        {
+                            "type": "response",
+                            "status_code": 404,
+                        }
+                    ],
                 },
             ],
         },

--- a/integration_tests/test_link_error.py
+++ b/integration_tests/test_link_error.py
@@ -30,10 +30,13 @@ def test_json(http_server) -> None:
             "links": [
                 {
                     "href": "http://localhost:5001",
-                    "destination": {
-                        "url": "http://localhost:5001",
-                        "status_code": None,
-                    },
+                    "url": "http://localhost:5001",
+                    "results": [
+                        {
+                            "type": "request_error",
+                            "message": "All connection attempts failed",
+                        },
+                    ],
                 },
             ],
         },

--- a/integration_tests/test_link_redirect.py
+++ b/integration_tests/test_link_redirect.py
@@ -1,0 +1,149 @@
+import json
+import subprocess
+
+from flask import Blueprint, redirect
+
+from . import util
+
+
+def make_blueprint() -> Blueprint:
+    blueprint = Blueprint("main", __name__)
+
+    @blueprint.route("/")
+    def root():
+        return """
+            <a href="/foo">
+            <a href="/bar">
+        """
+
+    @blueprint.route("/foo")
+    def foo():
+        return redirect("/baz")
+
+    @blueprint.route("/bar")
+    def bar():
+        return redirect("/nx")
+
+    @blueprint.route("/baz")
+    def baz():
+        return """<a href="/">\n"""
+
+    return blueprint
+
+
+def test_text(http_server) -> None:
+    http_server(blueprint=make_blueprint(), port=5000)
+
+    result = subprocess.run(
+        util.command(url="http://localhost:5000"),
+        stdout=subprocess.PIPE,
+    )
+
+    assert result.returncode == 1
+    assert result.stdout.decode() == util.output_str(
+        """
+        http://localhost:5000
+          - /bar: 302 → 404
+        http://localhost:5000/
+          - /bar: 302 → 404
+        """
+    )
+
+
+def test_json(http_server) -> None:
+    http_server(blueprint=make_blueprint(), port=5000)
+
+    result = subprocess.run(
+        util.command(url="http://localhost:5000", json=True),
+        stdout=subprocess.PIPE,
+    )
+
+    assert result.returncode == 1
+    assert json.loads(result.stdout.decode()) == {
+        "http://localhost:5000": {
+            "links": [
+                {
+                    "href": "/foo",
+                    "url": "http://localhost:5000/foo",
+                    "results": [
+                        {
+                            "type": "redirect",
+                            "status_code": 302,
+                            "value": "/baz",
+                            "url": "http://localhost:5000/baz",
+                        },
+                        {
+                            "type": "response",
+                            "status_code": 200,
+                        },
+                    ],
+                },
+                {
+                    "href": "/bar",
+                    "url": "http://localhost:5000/bar",
+                    "results": [
+                        {
+                            "type": "redirect",
+                            "status_code": 302,
+                            "value": "/nx",
+                            "url": "http://localhost:5000/nx",
+                        },
+                        {
+                            "type": "response",
+                            "status_code": 404,
+                        },
+                    ],
+                },
+            ],
+        },
+        "http://localhost:5000/": {
+            "links": [
+                {
+                    "href": "/foo",
+                    "url": "http://localhost:5000/foo",
+                    "results": [
+                        {
+                            "type": "redirect",
+                            "status_code": 302,
+                            "value": "/baz",
+                            "url": "http://localhost:5000/baz",
+                        },
+                        {
+                            "type": "response",
+                            "status_code": 200,
+                        },
+                    ],
+                },
+                {
+                    "href": "/bar",
+                    "url": "http://localhost:5000/bar",
+                    "results": [
+                        {
+                            "type": "redirect",
+                            "status_code": 302,
+                            "value": "/nx",
+                            "url": "http://localhost:5000/nx",
+                        },
+                        {
+                            "type": "response",
+                            "status_code": 404,
+                        },
+                    ],
+                },
+            ],
+        },
+        "http://localhost:5000/baz": {
+            "links": [
+                {
+                    "href": "/",
+                    "url": "http://localhost:5000/",
+                    "results": [
+                        {
+                            "type": "response",
+                            "status_code": 200,
+                        },
+                    ],
+                },
+            ],
+        },
+    }

--- a/integration_tests/test_no_scheme.py
+++ b/integration_tests/test_no_scheme.py
@@ -30,10 +30,13 @@ def test_json(http_server) -> None:
             "links": [
                 {
                     "href": "",
-                    "destination": {
-                        "url": "http://localhost:5000",
-                        "status_code": 200,
-                    },
+                    "url": "http://localhost:5000",
+                    "results": [
+                        {
+                            "type": "response",
+                            "status_code": 200,
+                        }
+                    ],
                 },
             ],
         },

--- a/integration_tests/test_other_server.py
+++ b/integration_tests/test_other_server.py
@@ -31,10 +31,13 @@ def test_json(http_server) -> None:
             "links": [
                 {
                     "href": "http://localhost:5001",
-                    "destination": {
-                        "url": "http://localhost:5001",
-                        "status_code": 200,
-                    },
+                    "url": "http://localhost:5001",
+                    "results": [
+                        {
+                            "type": "response",
+                            "status_code": 200,
+                        },
+                    ],
                 },
             ],
         },

--- a/integration_tests/test_recursive.py
+++ b/integration_tests/test_recursive.py
@@ -59,10 +59,13 @@ def test_json(max_parallel_requests: int, http_server) -> None:
             "links": [
                 {
                     "href": "/foo",
-                    "destination": {
-                        "url": "http://localhost:5000/foo",
-                        "status_code": 200,
-                    },
+                    "url": "http://localhost:5000/foo",
+                    "results": [
+                        {
+                            "type": "response",
+                            "status_code": 200,
+                        }
+                    ],
                 },
             ],
         },
@@ -70,10 +73,13 @@ def test_json(max_parallel_requests: int, http_server) -> None:
             "links": [
                 {
                     "href": "/foo",
-                    "destination": {
-                        "url": "http://localhost:5000/foo",
-                        "status_code": 200,
-                    },
+                    "url": "http://localhost:5000/foo",
+                    "results": [
+                        {
+                            "type": "response",
+                            "status_code": 200,
+                        }
+                    ],
                 },
             ],
         },
@@ -81,10 +87,13 @@ def test_json(max_parallel_requests: int, http_server) -> None:
             "links": [
                 {
                     "href": "/",
-                    "destination": {
-                        "url": "http://localhost:5000/",
-                        "status_code": 200,
-                    },
+                    "url": "http://localhost:5000/",
+                    "results": [
+                        {
+                            "type": "response",
+                            "status_code": 200,
+                        }
+                    ],
                 },
             ],
         },

--- a/integration_tests/test_recursive_redirect.py
+++ b/integration_tests/test_recursive_redirect.py
@@ -1,0 +1,34 @@
+import subprocess
+
+from flask import Blueprint, redirect
+
+from . import util
+
+
+def make_blueprint() -> Blueprint:
+    blueprint = Blueprint("main", __name__)
+
+    @blueprint.route("/")
+    def root():
+        return redirect("/foo")
+
+    @blueprint.route("/foo")
+    def foo():
+        return redirect("/")
+
+    return blueprint
+
+
+def test_json(http_server) -> None:
+    http_server(blueprint=make_blueprint(), port=5000)
+
+    result = subprocess.run(
+        util.command(
+            url="http://localhost:5000",
+            json=True,
+        ),
+        stdout=subprocess.PIPE,
+    )
+
+    assert result.returncode == 1
+    assert result.stdout.decode() == ""

--- a/integration_tests/test_url_head_405.py
+++ b/integration_tests/test_url_head_405.py
@@ -48,10 +48,13 @@ def test_json(http_server) -> None:
             "links": [
                 {
                     "href": "http://localhost:5001",
-                    "destination": {
-                        "url": "http://localhost:5001",
-                        "status_code": 200,
-                    },
+                    "url": "http://localhost:5001",
+                    "results": [
+                        {
+                            "type": "response",
+                            "status_code": 200,
+                        }
+                    ],
                 },
             ],
         },

--- a/src/discolinks/link_store.py
+++ b/src/discolinks/link_store.py
@@ -2,16 +2,21 @@ from typing import Mapping, Optional, Sequence
 
 import attrs
 
+from . import outcome
 from .core import Link, Url
 
 
 @attrs.frozen
 class UrlInfo:
-    status_code: Optional[int]
+    result: outcome.Result
     links: Optional[Sequence[Link]]
 
     def link_urls(self) -> frozenset[Url]:
-        if self.links is None:
+        redirect_url = self.result.redirect_url()
+
+        if redirect_url is not None:
+            return frozenset([redirect_url])
+        elif self.links is None:
             return frozenset()
         else:
             return frozenset(link.url for link in self.links)

--- a/src/discolinks/outcome.py
+++ b/src/discolinks/outcome.py
@@ -1,0 +1,120 @@
+from abc import ABC, abstractmethod
+from typing import Generic, Optional, Sequence, TypeVar
+
+import attrs
+
+from .core import Url
+
+Out = TypeVar("Out")
+
+
+@attrs.frozen
+class Result(ABC):
+    @abstractmethod
+    def ok(self) -> bool:
+        pass
+
+    @abstractmethod
+    def status_code(self) -> Optional[int]:
+        pass
+
+    @abstractmethod
+    def redirect_url(self) -> Optional[Url]:
+        pass
+
+    @abstractmethod
+    def error_msg(self) -> Optional[str]:
+        pass
+
+    @abstractmethod
+    def convert_with(self, converter: "Converter[Out]") -> Out:
+        pass
+
+
+@attrs.frozen
+class Redirect(Result):
+    code: int
+    ref: str
+    url: Url
+
+    def ok(self) -> bool:
+        return True
+
+    def status_code(self) -> Optional[int]:
+        return self.code
+
+    def redirect_url(self) -> Optional[Url]:
+        return self.url
+
+    def error_msg(self) -> Optional[str]:
+        return None
+
+    def convert_with(self, converter: "Converter[Out]") -> Out:
+        return converter.convert_redirect(self)
+
+
+@attrs.frozen
+class Page(Result):
+    code: int
+    body: str
+
+    def ok(self) -> bool:
+        return not (400 <= self.code < 600)
+
+    def status_code(self) -> Optional[int]:
+        return self.code
+
+    def redirect_url(self) -> Optional[Url]:
+        return None
+
+    def error_msg(self) -> Optional[str]:
+        return None
+
+    def convert_with(self, converter: "Converter[Out]") -> Out:
+        return converter.convert_page(self)
+
+
+@attrs.frozen
+class RequestError(Result):
+    msg: str
+
+    def ok(self) -> bool:
+        return False
+
+    def status_code(self) -> Optional[int]:
+        return None
+
+    def redirect_url(self) -> Optional[Url]:
+        return None
+
+    def error_msg(self) -> Optional[str]:
+        return self.msg
+
+    def convert_with(self, converter: "Converter[Out]") -> Out:
+        return converter.convert_request_error(self)
+
+
+@attrs.frozen
+class Results:
+    chain: Sequence[Result]
+
+    def ok(self) -> bool:
+        final = self.chain[-1]
+        return final.ok()
+
+    def convert_with(self, converter: "Converter[Out]") -> Sequence[Out]:
+        return tuple(item.convert_with(converter) for item in self.chain)
+
+
+class Converter(ABC, Generic[Out]):
+    @abstractmethod
+    def convert_redirect(self, redirect: Redirect) -> Out:
+        pass
+
+    @abstractmethod
+    def convert_page(self, page: Page) -> Out:
+        pass
+
+    @abstractmethod
+    def convert_request_error(self, error: RequestError) -> Out:
+        pass

--- a/src/discolinks/requester.py
+++ b/src/discolinks/requester.py
@@ -3,72 +3,44 @@ import logging
 import attrs
 import httpx
 
+from . import outcome
 from .core import Url
 
 logger = logging.getLogger(__name__)
 
 
-@attrs.frozen
-class RequestError(Exception):
-    msg: str
-
-
-def status_code_ok(status_code: int) -> bool:
-    return not (400 <= status_code < 600)
-
-
-@attrs.frozen
-class HeadResponse:
-    status_code: int
-
-    def ok(self) -> bool:
-        return status_code_ok(self.status_code)
-
-
-@attrs.frozen
-class GetResponse:
-    status_code: int
-    body: str
-
-    def ok(self) -> bool:
-        return status_code_ok(self.status_code)
+def httpx_to_result(response: httpx.Response) -> outcome.Result:
+    if response.next_request is not None:
+        return outcome.Redirect(
+            code=response.status_code,
+            ref=response.headers["location"],
+            url=Url.from_str(str(response.next_request.url)),
+        )
+    else:
+        return outcome.Page(
+            code=response.status_code,
+            body=response.text,
+        )
 
 
 @attrs.frozen
 class Requester:
     client: httpx.AsyncClient = attrs.field(init=False, factory=httpx.AsyncClient)
 
-    async def head(self, link: Url) -> HeadResponse:
+    async def get(self, url: Url, use_head: bool = False) -> outcome.Result:
         """
-        Send a HEAD request to the given link.
+        Fetch a page from the given HTTP URL.
+        """
+        logger.debug("GET %s", url)
 
-        Raises `RequestError` if any connection issue is encountered.
-        """
-        logger.debug("HEAD %s", link)
+        if use_head:
+            method = "HEAD"
+        else:
+            method = "GET"
 
         try:
-            response = await self.client.head(link.full, follow_redirects=True)
-        except httpx.HTTPError as error:
-            raise RequestError(msg=str(error))
+            response = await self.client.request(method=method, url=url.full)
+        except httpx.RequestError as error:
+            return outcome.RequestError(msg=str(error))
 
-        return HeadResponse(
-            status_code=response.status_code,
-        )
-
-    async def get(self, link: Url) -> GetResponse:
-        """
-        Fetch an HTML page from the given link.
-
-        Raises `RequestError` if any connection issue is encountered.
-        """
-        logger.debug("GET %s", link)
-
-        try:
-            response = await self.client.get(link.full, follow_redirects=True)
-        except httpx.HTTPError as error:
-            raise RequestError(msg=str(error))
-
-        return GetResponse(
-            status_code=response.status_code,
-            body=response.text,
-        )
+        return httpx_to_result(response)

--- a/src/discolinks/text.py
+++ b/src/discolinks/text.py
@@ -1,0 +1,33 @@
+from typing import Mapping
+
+import attrs
+
+from . import analyzer, outcome
+from .core import Url
+
+
+@attrs.frozen
+class Converter(outcome.Converter[str]):
+    def convert_page(self, page: outcome.Page) -> str:
+        return str(page.code)
+
+    def convert_redirect(self, redirect: outcome.Redirect) -> str:
+        return str(redirect.code)
+
+    def convert_request_error(self, error: outcome.RequestError) -> str:
+        return str(error.msg)
+
+
+def print_results(pages: Mapping[Url, analyzer.Page]) -> None:
+    for (url, info) in pages.items():
+        bad_links = [link for link in info.links if not link.ok()]
+
+        if not bad_links:
+            continue
+
+        print(f"{url}")
+
+        for link in bad_links:
+            items = link.results.convert_with(Converter())
+            results = " → ".join(items)
+            print(f"  - {link.href}: {results}")


### PR DESCRIPTION
Redirects were previously handled implicitly and ignored, which means that the source URL would often be considered to be the location of a page. For example, if `example.net/foo` redirected to `example.net/bar`, it would consider `/foo` to be a page with links, which is kind of wrong.

Instead, redirects are followed just like links on a page and intermediate results are stored in the store. The only exception is the starting point, which is still handled a bit differently.

Thanks to this change, we avoid visiting redirection targets if we've visited them before. This wasn't the case before.

The output format (text or JSON) was also changed. It now shows the redirection path for each link on a page.