### PR TITLE
Handle unknown URL schemes

### DIFF
--- a/src/discolinks/html.py
+++ b/src/discolinks/html.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import Optional, Sequence
 from urllib.parse import urldefrag, urljoin, urlparse
 
 import bs4
@@ -9,14 +9,10 @@ from .core import Link, Url
 def get_hrefs(body: str) -> Sequence[str]:
     soup = bs4.BeautifulSoup(body, features="html.parser")
 
-    return [
-        url
-        for a in soup.find_all("a")
-        if (url := a.attrs.get("href")) is not None and not url.startswith("mailto:")
-    ]
+    return [url for a in soup.find_all("a") if (url := a.attrs.get("href")) is not None]
 
 
-def parse_href(href: str, base_url: Url) -> Url:
+def parse_href(href: str, base_url: Url) -> Optional[Url]:
     """
     Parse the value of an `href` HTML attribute into a URL.
 
@@ -25,6 +21,9 @@ def parse_href(href: str, base_url: Url) -> Url:
 
     (href, _) = urldefrag(href)
     parsed = urlparse(href)
+
+    if parsed.scheme not in ("", "http", "https"):
+        return None
 
     if parsed.netloc:
         url = href
@@ -36,5 +35,7 @@ def parse_href(href: str, base_url: Url) -> Url:
 
 def get_links(body: str, url: Url) -> Sequence[Link]:
     return [
-        Link(href=href, url=parse_href(href, base_url=url)) for href in get_hrefs(body)
+        Link(href=href, url=link_url)
+        for href in get_hrefs(body)
+        if (link_url := parse_href(href, base_url=url)) is not None
     ]

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -12,7 +12,7 @@ from discolinks.html import get_hrefs, parse_href
         ("<body></body>", []),
         ("""<a href="foo">""", ["foo"]),
         ("""<a href="foo#bar">""", ["foo#bar"]),
-        ("""<a href="mailto:foo@example.net">""", []),
+        ("""<a href="mailto:foo@example.net">""", ["mailto:foo@example.net"]),
     ],
 )
 def test_get_hrefs(body: str, expected: Sequence[str]):
@@ -58,6 +58,16 @@ def test_get_hrefs(body: str, expected: Sequence[str]):
             "http://example.org",
             Url.from_str("http://example.net"),
             Url.from_str("http://example.org"),
+        ),
+        (
+            "mailto:foo@example.net",
+            Url.from_str("http://example.net"),
+            None,
+        ),
+        (
+            "tel:+0123",
+            Url.from_str("http://example.net"),
+            None,
         ),
     ],
 )


### PR DESCRIPTION
The parser previously explicitly excluded the `mailto` scheme to avoid crashing when encountering such a scheme in an `href` attribute. Unfortunately, this approach doesn't work given all the potential schemes to be observed (see https://en.wikipedia.org/wiki/List_of_URI_schemes for more information).

As a result, the parser now only accepts listed schemes (it uses an allow list instead of a deny list). That should make it much more robust.