### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10']
+        python-version: ['3.9', '3.11']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - run: pip install --upgrade pip poetry
       - run: poetry install
       - run: poetry run make check-lint

--- a/src/discolinks/cli.py
+++ b/src/discolinks/cli.py
@@ -68,10 +68,8 @@ async def find_links(
 
     # Wait for queue processing to finish, or for any worker to finish (which only happens
     # if that worker raised an exception).
-    await asyncio.wait(
-        [queue.join(), *workers],
-        return_when=asyncio.FIRST_COMPLETED,
-    )
+    queue_task = asyncio.create_task(queue.join())
+    await asyncio.wait([queue_task, *workers], return_when=asyncio.FIRST_COMPLETED)
 
     for worker in workers:
         worker.cancel()


### PR DESCRIPTION
The `asyncio.wait` function no longer takes coroutines as argument, only tasks. See
https://docs.python.org/3/library/asyncio-task.html#asyncio.wait.