### PR TITLE
Remove warning when encountering XML

### DIFF
--- a/src/discolinks/html.py
+++ b/src/discolinks/html.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Optional, Sequence
 from urllib.parse import urldefrag, urljoin, urlparse
 
@@ -7,7 +8,9 @@ from .core import Link, Url
 
 
 def get_hrefs(body: str) -> Sequence[str]:
-    soup = bs4.BeautifulSoup(body, features="html.parser")
+    with warnings.catch_warnings():
+        warnings.simplefilter(action="ignore", category=bs4.XMLParsedAsHTMLWarning)
+        soup = bs4.BeautifulSoup(body, features="html.parser")
 
     return [url for a in soup.find_all("a") if (url := a.attrs.get("href")) is not None]
 

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -13,6 +13,15 @@ from discolinks.html import get_hrefs, parse_href
         ("""<a href="foo">""", ["foo"]),
         ("""<a href="foo#bar">""", ["foo#bar"]),
         ("""<a href="mailto:foo@example.net">""", ["mailto:foo@example.net"]),
+        (
+            """
+            <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+            <svg>
+                <a href="foo"></a>
+            </svg>
+            """,
+            ["foo"],
+        ),
     ],
 )
 def test_get_hrefs(body: str, expected: Sequence[str]):


### PR DESCRIPTION
Even though we may not parse it as well as if we were using a specialized parser.

The warning:

    /home/bertrand/code/discolinks/.venv/lib/python3.11/site-packages/bs4/builder/__init__.py:545:
    XMLParsedAsHTMLWarning: It looks like you're parsing an XML document
    using an HTML parser. If this really is an HTML document (maybe it's
    XHTML?), you can ignore or filter this warning. If it's XML, you
    should know that using an XML parser will be more reliable. To parse
    this document as XML, make sure you have the lxml package installed,
    and pass the keyword argument `features="xml"` into the
    BeautifulSoup constructor.