### PR TITLE
Add `--exclude` to avoid retrieving some URLs

### DIFF
--- a/integration_tests/test_exclude.py
+++ b/integration_tests/test_exclude.py
@@ -1,0 +1,63 @@
+import json
+import subprocess
+
+from flask import Blueprint
+
+from . import util
+
+
+def make_blueprint() -> Blueprint:
+    blueprint = Blueprint("main", __name__)
+
+    @blueprint.route("/")
+    def root():
+        return """
+            <a href="/foo"></a>
+        """
+
+    @blueprint.route("/foo")
+    def foo():
+        return """
+            <a href="/nonexistent"></a>
+        """
+
+    return blueprint
+
+
+def test_ok(http_server) -> None:
+    http_server(make_blueprint(), port=5000)
+
+    result = subprocess.run(
+        util.command(url="http://localhost:5000", exclude=["foo"], json=True),
+        stdout=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0
+    assert json.loads(result.stdout.decode()) == {
+        "http://localhost:5000": {
+            "links": [
+                {
+                    "href": "/foo",
+                    "url": "http://localhost:5000/foo",
+                    "results": [
+                        {
+                            "type": "excluded",
+                        },
+                    ],
+                },
+            ],
+        },
+    }
+
+
+def test_bad_regex(http_server) -> None:
+    http_server(make_blueprint(), port=5000)
+
+    result = subprocess.run(
+        util.command(url="http://localhost:5000", exclude=["("], json=True),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 1
+    assert result.stdout.decode() == ""

--- a/integration_tests/util.py
+++ b/integration_tests/util.py
@@ -11,6 +11,7 @@ def command(
     url: str,
     verbose: Optional[bool] = None,
     json: Optional[bool] = None,
+    exclude: Sequence[str] = (),
     max_parallel_requests: Optional[int] = None,
 ) -> Sequence[str]:
     """
@@ -27,6 +28,9 @@ def command(
 
     if json:
         cli += ["--json"]
+
+    for s in exclude:
+        cli += ["--exclude", s]
 
     if max_parallel_requests is not None:
         cli += ["--max-parallel-requests", str(max_parallel_requests)]

--- a/src/discolinks/excluder.py
+++ b/src/discolinks/excluder.py
@@ -1,0 +1,41 @@
+import re
+from typing import Sequence
+
+import attrs
+
+from .core import Url
+
+
+@attrs.frozen
+class ExcluderRegexError(Exception):
+    regex: str
+    msg: str
+
+
+def parse_regex(regex: str) -> re.Pattern:
+    try:
+        return re.compile(regex)
+    except re.error as error:
+        raise ExcluderRegexError(regex=regex, msg=str(error))
+
+
+@attrs.frozen
+class Excluder:
+    """
+    Preprocessed engine excluding certain URLs
+    """
+
+    patterns: Sequence[re.Pattern]
+
+    @classmethod
+    def from_regexes(cls, regexes: Sequence[str]) -> "Excluder":
+        """
+        Parse regular expressions to be used as exclusion patterns.
+
+        Raises `ExcluderRegexError` if any of the regexes can't be parsed.
+        """
+        patterns = [parse_regex(regex) for regex in regexes]
+        return cls(patterns=patterns)
+
+    def is_excluded(self, url: Url) -> bool:
+        return any(re.search(pattern, str(url)) for pattern in self.patterns)

--- a/src/discolinks/export.py
+++ b/src/discolinks/export.py
@@ -30,6 +30,11 @@ class Converter(outcome.Converter[Any]):
             "message": str(error.msg),
         }
 
+    def convert_excluded(self, unknown: outcome.Excluded) -> Any:
+        return {
+            "type": "excluded",
+        }
+
     def convert_unknown(self, unknown: outcome.Unknown) -> Any:
         return {
             "type": "unknown",

--- a/src/discolinks/link_extractor.py
+++ b/src/discolinks/link_extractor.py
@@ -19,6 +19,9 @@ class LinkExtractor(outcome.Converter[Optional[Sequence[Link]]]):
     def convert_request_error(self, error: outcome.RequestError) -> None:
         return None
 
+    def convert_excluded(self, excluded: outcome.Excluded) -> None:
+        return None
+
     def convert_unknown(self, unknown: outcome.Unknown) -> None:
         return None
 

--- a/src/discolinks/outcome.py
+++ b/src/discolinks/outcome.py
@@ -95,6 +95,24 @@ class RequestError(Result):
 
 
 @attrs.frozen
+class Excluded(Result):
+    def ok(self) -> bool:
+        return True
+
+    def status_code(self) -> Optional[int]:
+        return None
+
+    def redirect_url(self) -> Optional[Url]:
+        return None
+
+    def error_msg(self) -> Optional[str]:
+        return None
+
+    def convert_with(self, converter: "Converter[Out]") -> Out:
+        return converter.convert_excluded(self)
+
+
+@attrs.frozen
 class Unknown(Result):
     def ok(self) -> bool:
         # It's considered OK because the underlying error will be reported by another
@@ -137,6 +155,10 @@ class Converter(ABC, Generic[Out]):
 
     @abstractmethod
     def convert_request_error(self, error: RequestError) -> Out:
+        pass
+
+    @abstractmethod
+    def convert_excluded(self, excluded: Excluded) -> Out:
         pass
 
     @abstractmethod

--- a/src/discolinks/text.py
+++ b/src/discolinks/text.py
@@ -17,6 +17,9 @@ class Converter(outcome.Converter[str]):
     def convert_request_error(self, error: outcome.RequestError) -> str:
         return f"[red]{escape(str(error.msg))}[/red]"
 
+    def convert_excluded(self, excluded: outcome.Excluded) -> str:
+        return "excluded"
+
     def convert_unknown(self, unknown: outcome.Unknown) -> str:
         assert False, "`Unknown` result isn't supposed to be shown"
 

--- a/tests/test_excluder.py
+++ b/tests/test_excluder.py
@@ -1,0 +1,30 @@
+import pytest
+
+from discolinks.core import Url
+from discolinks.excluder import Excluder, ExcluderRegexError
+
+
+def test_excluder_from_regexes_error():
+    with pytest.raises(ExcluderRegexError) as error:
+        Excluder.from_regexes("(")
+
+    assert error.value.regex == "("
+    assert error.value.msg == "missing ), unterminated subpattern at position 0"
+
+
+@pytest.mark.parametrize(
+    "regexes,url,expected",
+    [
+        ([], Url.from_str("https://foo"), False),
+        (["a"], Url.from_str("https://foo"), False),
+        (["f"], Url.from_str("https://foo"), True),
+        (["^f"], Url.from_str("https://foo"), False),
+        (["^h"], Url.from_str("https://foo"), True),
+        (["a", "b"], Url.from_str("https://foo"), False),
+        (["a", "f"], Url.from_str("https://foo"), True),
+    ],
+)
+def test_excluder_combined(regexes: str, url: Url, expected: bool):
+    result = Excluder.from_regexes(regexes).is_excluded(url)
+
+    assert result is expected


### PR DESCRIPTION
This is a new parameter of the CLI. It enables the user to specify one or more regular expressions which define a set of URLs that the crawler won't use.