### PR TITLE
Fix event loop creation for Python 3.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.12']
+        python-version: ['3.9', '3.14']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.14'
       - run: pip install --upgrade pip uv
       - run: uv sync
       - run: uv run make check-lint

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -1,32 +1,26 @@
-from multiprocessing import Process
+from threading import Thread
 
 import pytest
 from flask import Blueprint
+from werkzeug.serving import make_server
 
 from . import server
-
-
-def launch_process(target, kwargs) -> Process:
-    process = Process(target=target, kwargs=kwargs)
-    process.start()
-    return process
 
 
 @pytest.fixture
 def http_server():
     created_servers = {}
 
-    def _make_server(blueprint: Blueprint, port: int) -> Process:
+    def _make_server(blueprint: Blueprint, port: int) -> None:
         app = server.create_app(blueprint=blueprint)
-        process = launch_process(target=app.run, kwargs={"port": port})
-        created_servers[port] = process
-        return process
+        srv = make_server("127.0.0.1", port, app)
+        thread = Thread(target=srv.serve_forever)
+        thread.daemon = True
+        thread.start()
+        created_servers[port] = (thread, srv)
 
     yield _make_server
 
-    errors = []
-    for port, process in created_servers.items():
-        if process.exitcode is not None:
-            errors.append(f"Server failure for port {port}")
-        process.terminate()
-    assert not errors
+    for thread, srv in created_servers.values():
+        srv.shutdown()
+        thread.join()

--- a/src/discolinks/cli.py
+++ b/src/discolinks/cli.py
@@ -199,6 +199,10 @@ def main(
 
     try:
         with new_monitor(console=console) as monitor:
+            # Set event loop
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
             # Define main task (wrap in a future to make it cancellable).
             main_task = asyncio.ensure_future(
                 main_async(
@@ -211,7 +215,6 @@ def main(
             )
 
             # Cancel main task when interrupted.
-            loop = asyncio.get_event_loop()
             loop.add_signal_handler(
                 signal.SIGINT,
                 functools.partial(main_task.cancel, msg="SIGINT"),


### PR DESCRIPTION
- Create the event loop, because it's not created implicitly in Python 3.14.
- Use threads for integration testing, to avoid an incompatibility with `pickle` and the serialiazation of Flask objects.